### PR TITLE
Split PHP milestones into smaller milestones

### DIFF
--- a/milestones.md
+++ b/milestones.md
@@ -10,10 +10,8 @@ The milestones are:
 
 1. Identity
    - 1a. Test Suite (€5,000)
-   - 1b. Standalone PHP (€2,500)
-   - 1c. Nextcloud Integration (€2,500)
-   - 1d. Standalone PHP server(€2,500)
-   - 1c. Nextcloud Integration (€2,500)
+   - 1b. Standalone PHP server(€5,000)
+   - 1c. Nextcloud Integration (€5,000)
 
 2. Storage API
    - 2a. Test Suite (€5,000)
@@ -25,16 +23,10 @@ The milestones are:
    - 3b. Standalone PHP (€2,500)
    - 3c. Nextcloud Integration (€2,500)
 
-4. Deep Integration
-   - Solid App Launcher
-     - 4a. Standalone PHP (€2,500)
-     - 4b. Nextcloud Integration (€2,500)
-   - Contacts and Profile
-     - 4c. Standalone PHP (€2,500)
-     - 4d. Nextcloud Integration (€2,500)
-   - Calendar
-     - 4e. Standalone PHP (€2,500)
-     - 4f. Nextcloud Integration (€2,500)
+4. Deep Integration with Nextcloud
+   - 4a. Solid App Launcher (€5,500)
+   - 4b. Contacts and Profile (€5,000)
+   - 4c. Calendar (€5,000)
 
 Each milestone is described in more detail below.
 
@@ -62,7 +54,7 @@ This milestone is for writing the parts of the test-suite that relate to:
 - Correctness of the authorization endpoint
 - Fetching the OpenID config
 - Fetching the WebID profile
-- Working with web tokens
+- Generating access tokens
 
 The tests which will check compatibility between our implementation in PHP
 (Nextcloud-based/stand-alone), Node, and Solid-App-Kit.
@@ -74,35 +66,26 @@ sections in the official Solid spec.
 ### 1b. Standalone PHP
 
 This milestone will be for creating an empty standalone PHP server (that all
-following standalone PHP milestones will be implemented in) and an identity
-(WebID profile) that passes the relevant tests from the Identity Test Suite
-milestone.
-
-### 1c. Nextcloud Integration
-
-This milestone will be for a Nextcloud app (that all following Nextcloud
-milestones will be implemented in) and a WebID profile that passes the relevant
-tests in the test-suite from the Identity Test Suite milestone.
-
-The data in the profile will be based on user data from the Nextcloud database.
-
-### 1d. Standalone PHP server
-
-This milestone will be for implementing a Solid identity provider in PHP
+following standalone PHP milestones will be implemented in), an identity
+(WebID profile), and a Solid identity provider in PHP.
 
 Any generic parts will be implemented as package(s) that can be re-used by the
 Nextcloud integration (and any future PHP implementations).
 
-The implementation will pass rest of the test in the test-suite from the
-Identity Test Suite milestone.
+The implementation will pass all of the test in the test-suite from the
+Identity Test Suite milestone (1a).
 
-### 1e. Nextcloud Integration
+### 1c. Nextcloud Integration
 
-This milestone will be for integrating the Solid identity provider into the
-Nextcloud app (using any packages created in the previous milestone).
+This milestone will be for a Nextcloud app (that all following Nextcloud
+milestones will be implemented in), a WebID profile, and integrate the Solid
+identity provider into the Nextcloud app (using any packages created in the 
+previous milestone).
 
-This will be done in such a way that Nextcloud's existing single sign-on feature
-will be used as the user login database.
+The data in the profile will be based on user data from the Nextcloud database.
+
+The identity provider will use Nextcloud's existing single  sign-on feature as
+the user login database.
 
 The implementation will pass all relevant tests from the Identity Test Suite
 milestone.
@@ -189,7 +172,7 @@ milestone.
 
 ## 4. Deep Integration
 
-### Solid App Launcher
+### 4a. Solid App Launcher
 
 A crucial part of Solid is allowing the user to control who gets access to which
 part of their data. The basis for this was developed last year at Inrupt, called
@@ -200,18 +183,9 @@ The index of apps this launcher recognizes (and exact permissions each app
 requests) will be detailed on a dedicated public web page on https://pdsinterop.org/,
 with links to the relevant sections in the official Solid spec.
 
-### 4a. Standalone PHP
+This milestone will implement the Solid App Launcher in the Nextcloud app.
 
-This milestone will implement the Solid App Launcher in standalone PHP, in such
-a way that any generic parts can be re-used (as package) in the Nextcloud
-integration.
-
-### 4b. Nextcloud Integration
-
-This milestone will include the integration of the Solid App Launcher into the
-Nextcloud app (using any packages created in the previous milestone).
-
-### Contacts and Profile
+### 4b. Contacts and Profile
 
 Nextcloud users already have profile data like full name and avatar in their
 user account, and they also already have a Nextcloud addressbook in which they
@@ -224,18 +198,11 @@ The details of both the Solid and the Nextcloud data format for this will be
 detailed on a dedicated public web page on https://pdsinterop.org/, with links
 to the relevant sections in the official Solid spec.
 
-### 4c. Standalone PHP
+This milestone will implement Contacts and Profile in the Nextcloud app.
+This is an addition to the WebID profile from the "Identity Nextcloud 
+Integration" milestone (1c).
 
-This milestone will implement Contacts and Profile in standalone PHP, in such a
-way that any generic parts can be re-used (as package) in the Nextcloud
-integration.
-
-### 4d. Nextcloud Integration
-
-This milestone will include the integration of Contacts and Profile into the
-Nextcloud app (using any packages created in the previous milestone).
-
-### Calendar
+### 4c. Calendar
 
 Same as with Contacts and Profile but unlocking the user's Nextcloud-native
 calendar events as Solid-native calendar events.
@@ -250,12 +217,4 @@ The details of both the Solid and the Nextcloud data format for this will be
 detailed on a dedicated public web page on https://pdsinterop.org/, with links
 to the relevant sections in the official Solid spec.
 
-### 4e. Standalone PHP
-
-This milestone will implement Calendar in standalone PHP, in such a way that any
-generic parts can be re-used (as package) in the Nextcloud integration.
-
-### 4f. Nextcloud Integration
-
-This milestone will include the integration of Calendar into the Nextcloud app
-(using any packages created in the previous milestone).
+This milestone will implement Calendar in the Nextcloud app.

--- a/milestones.md
+++ b/milestones.md
@@ -1,125 +1,261 @@
 # Milestones
 
-For each of these 10 milestones (organized in 4 topics) we will request payment of
-5,000 euros from the [Next Generation Internet Privacy & Trust Enhancing Technologies
-(NGI-Zero:PET) grant](https://nlnet.nl/PET/) we received (total: 50,000 euros).
+All of these milestones are organized in 4 topics.
+We will request payment of 5,000 euros (for large milestones) or 2,500 euros
+(for small milestones) from the [Next Generation Internet Privacy & Trust
+Enhancing Technologies (NGI-Zero:PET) grant](https://nlnet.nl/PET/) for a total
+of 50,000 euros.
 
 The milestones are:
 
 1. Identity
-   - 1a. Test Suite
-   - 1b. Standalone PHP
-   - 1c. Nextcloud Integration
+   - 1a. Test Suite (€5,000)
+   - 1b. Standalone PHP (€2,500)
+   - 1c. Nextcloud Integration (€2,500)
+   - 1d. Standalone PHP server(€2,500)
+   - 1c. Nextcloud Integration (€2,500)
+
 2. Storage API
-   - 2a. Test Suite
-   - 2b. Implementation
+   - 2a. Test Suite (€5,000)
+   - 2b. Standalone PHP (€2,500)
+   - 2c. Nextcloud Integration (€2,500)
+
 3. Web ACL
-   - 3a. Test Suite
-   - 3b. Implementation
+   - 3a. Test Suite (€5,000)
+   - 3b. Standalone PHP (€2,500)
+   - 3c. Nextcloud Integration (€2,500)
+
 4. Deep Integration
-   - 4a. Solid App Launcher
-   - 4b. Contacts and Profile
-   - 4c. Calendar
+   - Solid App Launcher
+     - 4a. Standalone PHP (€2,500)
+     - 4b. Nextcloud Integration (€2,500)
+   - Contacts and Profile
+     - 4c. Standalone PHP (€2,500)
+     - 4d. Nextcloud Integration (€2,500)
+   - Calendar
+     - 4e. Standalone PHP (€2,500)
+     - 4f. Nextcloud Integration (€2,500)
 
 Each milestone is described in more detail below.
 
 ## 1. Identity
 
+The Solid identity protocol was changed in 2019 and is again being changed in
+2020. A [test-suite](https://github.com/solid/test-suite) for the 2019 version
+of webid-oidc was developed by [Inrupt](https://inrupt.com), but it was
+incomplete and partially incorrect.
+
+The official documentation for the 2020 version of the [WebID-OIDC](https://github.com/solid/webid-oidc-spec)
+protocol using [DPop](https://tools.ietf.org/html/draft-fett-oauth-dpop-04) has
+not yet been finalized, and ours will be among the first implementations of it,
+along with [Node-Solid-Server]( https://github.com/solid/node-solid-server) and
+[Solid-App-Kit](https://github.com/michielbdejong/solid-app-kit).
+
+This means that in order to implement it in PHP, we need a reliable test-suite
+first, that tests whether a given server is acting as a spec-compliant identity
+provider.
+
 ### 1a. Test Suite
 
-The Solid identity protocol was changed in 2019 and is again being changed
-in 2020. A [test-suite](https://github.com/solid/test-suite) for the 2019 version
-of webid-oidc was developed by [Inrupt](https://inrupt.com),
-but it was incomplete and partially incorrect. The official documentation for the 2020
-version of the [WebID-OIDC](https://github.com/solid/webid-oidc-spec) protocol using
-[DPop](https://tools.ietf.org/html/draft-fett-oauth-dpop-04) has not yet been finalized, and
-ours will be among the first implementations of it, along with
-[Node-Solid-Server]( https://github.com/solid/node-solid-server) and
-[Solid-App-Kit](https://github.com/michielbdejong/solid-app-kit).
-This means that in order to implement it in PHP, we need a reliable
-test-suite first, that tests whether a given server is acting as a spec-compliant
-identity provider. This milestone is for writing this test-suite, which will check
-compatibility between our implementation in PHP (Nextcloud-based/stand-alone),
-Node-Solid-Server, and Solid-App-Kit. The exact test criteria this test suite tests for
-will be detailed on a dedicated public web page on https://pdsinterop.org/, with links
-to the relevant sections in the official Solid spec.
+This milestone is for writing the parts of the test-suite that relate to:
+
+- Correctness of the authorization endpoint
+- Fetching the OpenID config
+- Fetching the WebID profile
+- Working with web tokens
+
+The tests which will check compatibility between our implementation in PHP
+(Nextcloud-based/stand-alone), Node, and Solid-App-Kit.
+
+The exact test criteria this test suite tests for will be detailed on a
+dedicated public web page on https://pdsinterop.org/, with links to the relevant
+sections in the official Solid spec.
 
 ### 1b. Standalone PHP
 
-This milestone will be for implementing a Solid identity provider in PHP,
-that passes the test-suite from the previous milestone.
+This milestone will be for creating an empty standalone PHP server (that all
+following standalone PHP milestones will be implemented in) and an identity
+(WebID profile) that passes the relevant tests from the Identity Test Suite
+milestone.
 
 ### 1c. Nextcloud Integration
 
-This milestone will be for integrating the Solid identity provider from the previous
-milestone into Nextcloud, as a Nextcloud app, in such a way that Nextcloud's existing
-single sign-on feature will be used as the user login database.
+This milestone will be for a Nextcloud app (that all following Nextcloud
+milestones will be implemented in) and a WebID profile that passes the relevant
+tests in the test-suite from the Identity Test Suite milestone.
+
+The data in the profile will be based on user data from the Nextcloud database.
+
+### 1d. Standalone PHP server
+
+This milestone will be for implementing a Solid identity provider in PHP
+
+Any generic parts will be implemented as package(s) that can be re-used by the
+Nextcloud integration (and any future PHP implementations).
+
+The implementation will pass rest of the test in the test-suite from the
+Identity Test Suite milestone.
+
+### 1e. Nextcloud Integration
+
+This milestone will be for integrating the Solid identity provider into the
+Nextcloud app (using any packages created in the previous milestone).
+
+This will be done in such a way that Nextcloud's existing single sign-on feature
+will be used as the user login database.
+
+The implementation will pass all relevant tests from the Identity Test Suite
+milestone.
 
 ## 2. Storage API
 
+Part of this is already tested by the LDP-BasicContainer test-suite, but for
+many details (such as filename encoding, recursive deletes, sparql-update and
+race conditions), a reliable test suite is still needed.
+
+This will to the benefit of both our project as well as future Solid server
+implementation projects.
+
 ### 2a. Test Suite
 
-This milestone will be for providing a test suite that tests the different behaviours which
-the storage API of a Solid server needs to implement. Part of this is already tested by the LDP-BasicContainer
-test-suite, but for many details such as filename encoding, recursive deletes, sparql-update
-and race conditions, a reliable test suite is still needed, both for our project and for other Solid server
-implementation projects to benefit from. The exact test criteria this test suite tests for
-will be detailed on a dedicated public web page on https://pdsinterop.org/, with links
-to the relevant sections in the official Solid spec.
+This milestone will be for providing a test suite that tests the different
+behaviours which the storage API of a Solid server needs to implement.
 
-### 2b. Implementation
+The exact test criteria this test suite tests for will be detailed on a
+dedicated public web page on https://pdsinterop.org/, with links to the relevant
+sections in the official Solid spec.
 
-This milestone will include both the implementation of the Solid storage API in PHP, and the integration
-of that component into the Nextcloud app which was created in milestone 1c. It encompasses the various
-HTTP verbs, as well as RDF-aware parts like sparql-update and content-negotiation.
+### 2b. Standalone PHP
+
+This milestone will implement the Solid storage API in standalone PHP, in such a
+way that any generic parts can be re-used (as package) in the Nextcloud
+integration.
+
+It encompasses the various HTTP verbs, as well as RDF-aware parts like
+sparql-update and content-negotiation.
+
+The implementation will pass all relevant tests from the Storage API Test Suite
+milestone.
+
+### 2c. Nextcloud Integration
+
+This milestone will include the integration of the Solid storage API into the
+Nextcloud app (using any packages created in the previous milestone).
+
+The implementation will pass all relevant tests from the Storage API Test Suite
+milestone.
 
 ## 3. Web ACL
 
+The Web ACL protocol is quite complex and at times confusing. One description of
+it is available at https://github.com/solid/web-access-control-spec, and a
+slightly more readable and explicit interpretation of it is available at
+https://unhosted.org/using-solid/.
+
+A reference implementation is available in Node-Solid-Server and Solid-App-Kit,
+however, no good test suite is available for it, so there would be no good way
+to know if our implementation would be compatible.
+
+**It is absolutely crucial for the security of private data that the Access
+Control Lists are interpreted in exactly the same way by each implementation of
+the Solid spec, including our Nextcloud-based one.**
+
 ### 3a. Test Suite
 
-The Web ACL protocol is quite complex and at times confusing. One description of it
-is available at https://github.com/solid/web-access-control-spec, and a slightly more
-readable and explicit interpretation of it is available at https://unhosted.org/using-solid/.
-A reference implementation is available in Node-Solid-Server and Solid-App-Kit, however,
-no good test suite is available for it, so there would be no good way to know if our implementation
-would be compatible. **It is absolutely crucial for the security of private data that the Access
-Control Lists are interpreted in exactly the same way by each implementation of the Solid spec,
-including our Nextcloud-based one.** This milestone will provide a test suite that checks and
-ensures that our implementation is both correct as intended, and compatible with other implementations.
-The exact test criteria this test-suite tests for will be detailed on a dedicated public web page on
-https://pdsinterop.org/, with links to the relevant sections in the official Solid spec.
+This milestone will provide a test suite that checks and ensures that our
+implementation is both correct as intended, and compatible with other
+implementations.
 
-### 3b. Implementation
+The exact test criteria this test-suite tests for will be detailed on a
+dedicated public web page on https://pdsinterop.org/, with links to the relevant
+sections in the official Solid spec.
 
-This milestone will include both the implementation of the Web Access Control spec in PHP, and the integration
-of that component into the Nextcloud app which was created in milestone 1c.
+### 3b. Standalone PHP
+
+This milestone will implement the Web Access Control spec in standalone PHP, in
+such a way that any generic parts can be re-used (as package) in the Nextcloud
+integration.
+
+The implementation will pass all relevant tests from the Web ACL Test Suite
+milestone.
+
+### 3c. Nextcloud Integration
+
+This milestone will include the integration of the Web Access Control spec into
+the Nextcloud app (using any packages created in the previous milestone).
+
+The implementation will pass all relevant tests from the Web ACL Test Suite
+milestone.
 
 ## 4. Deep Integration
 
-### 4a. Solid App Launcher
+### Solid App Launcher
 
-A crucial part of Solid is allowing the user to control who gets access to which part of their data. The basis
-for this was developed last year at Inrupt, called the Solid App Launcher, which we need to update and integrate
-into the user interface of both the stand-alone server and the Nextcloud integration app.
-The index of apps this launcher recognizes, and exact permissions each app requests
-will be detailed on a dedicated public web page on https://pdsinterop.org/, with links
+A crucial part of Solid is allowing the user to control who gets access to which
+part of their data. The basis for this was developed last year at Inrupt, called
+the Solid App Launcher, which we need to update and integrate into the user
+interface of both the stand-alone server and the Nextcloud integration app.
+
+The index of apps this launcher recognizes (and exact permissions each app
+requests) will be detailed on a dedicated public web page on https://pdsinterop.org/,
+with links to the relevant sections in the official Solid spec.
+
+### 4a. Standalone PHP
+
+This milestone will implement the Solid App Launcher in standalone PHP, in such
+a way that any generic parts can be re-used (as package) in the Nextcloud
+integration.
+
+### 4b. Nextcloud Integration
+
+This milestone will include the integration of the Solid App Launcher into the
+Nextcloud app (using any packages created in the previous milestone).
+
+### Contacts and Profile
+
+Nextcloud users already have profile data like full name and avatar in their
+user account, and they also already have a Nextcloud addressbook in which they
+keep track of their contacts, for instance for sharing Nextcloud documents.
+
+For this milestone we will unlock this data and make it available in the
+RDF-based Solid data format for profile and contacts data.
+
+The details of both the Solid and the Nextcloud data format for this will be
+detailed on a dedicated public web page on https://pdsinterop.org/, with links
 to the relevant sections in the official Solid spec.
 
-### 4b. Contacts and Profile
+### 4c. Standalone PHP
 
-Nextcloud users already have profile data like full name and avatar in their user account, and they also already
-have a Nextcloud addressbook in which they keep track of their contacts, for instance for sharing Nextcloud documents.
-For this milestone we will unlock this data and make it available in the RDF-based Solid data format for profile and
-contacts data.
-The details of both the Solid and the Nextcloud data format for this will be detailed on a dedicated public web page
-on https://pdsinterop.org/, with links to the relevant sections in the official Solid spec.
+This milestone will implement Contacts and Profile in standalone PHP, in such a
+way that any generic parts can be re-used (as package) in the Nextcloud
+integration.
 
-### 4c. Calendar
+### 4d. Nextcloud Integration
 
-Same as 4b. but unlocking the user's Nextcloud-native calendar events as Solid-native calendar events. Where certain
-fields don't have a mapping (e.g. if the Solid format has a maximum number of attendees for an event, but the Nextcloud
-format does not), they will simply be left blank. Other than that, it will be a great way to bootstrap the Solid app
-eco-system, where the millions of existing Nextcloud users can instantly use Solid apps with their existing data.
-The details of both the Solid and the Nextcloud data format for this will be detailed on a dedicated public web page
-on https://pdsinterop.org/, with links to the relevant sections in the official Solid spec.
+This milestone will include the integration of Contacts and Profile into the
+Nextcloud app (using any packages created in the previous milestone).
 
+### Calendar
+
+Same as with Contacts and Profile but unlocking the user's Nextcloud-native
+calendar events as Solid-native calendar events.
+
+Where certain fields don't have a mapping (e.g. if the Solid format has a
+maximum number of attendees for an event, but the Nextcloud format does not),
+they will simply be left blank. Other than that, it will be a great way to
+bootstrap the Solid app eco-system, where the millions of existing Nextcloud
+users can instantly use Solid apps with their existing data.
+
+The details of both the Solid and the Nextcloud data format for this will be
+detailed on a dedicated public web page on https://pdsinterop.org/, with links
+to the relevant sections in the official Solid spec.
+
+### 4e. Standalone PHP
+
+This milestone will implement Calendar in standalone PHP, in such a way that any
+generic parts can be re-used (as package) in the Nextcloud integration.
+
+### 4f. Nextcloud Integration
+
+This milestone will include the integration of Calendar into the Nextcloud app
+(using any packages created in the previous milestone).

--- a/milestones.md
+++ b/milestones.md
@@ -1,9 +1,32 @@
+# Milestones
+
 For each of these 10 milestones (organized in 4 topics) we will request payment of
 5,000 euros from the [Next Generation Internet Privacy & Trust Enhancing Technologies
 (NGI-Zero:PET) grant](https://nlnet.nl/PET/) we received (total: 50,000 euros).
 
-# 1. Identity
-## 1a. Test Suite
+The milestones are:
+
+1. Identity
+   - 1a. Test Suite
+   - 1b. Standalone PHP
+   - 1c. Nextcloud Integration
+2. Storage API
+   - 2a. Test Suite
+   - 2b. Implementation
+3. Web ACL
+   - 3a. Test Suite
+   - 3b. Implementation
+4. Deep Integration
+   - 4a. Solid App Launcher
+   - 4b. Contacts and Profile
+   - 4c. Calendar
+
+Each milestone is described in more detail below.
+
+## 1. Identity
+
+### 1a. Test Suite
+
 The Solid identity protocol was changed in 2019 and is again being changed
 in 2020. A [test-suite](https://github.com/solid/test-suite) for the 2019 version
 of webid-oidc was developed by [Inrupt](https://inrupt.com),
@@ -21,17 +44,21 @@ Node-Solid-Server, and Solid-App-Kit. The exact test criteria this test suite te
 will be detailed on a dedicated public web page on https://pdsinterop.org/, with links
 to the relevant sections in the official Solid spec.
 
-## 1b. Standalone
+### 1b. Standalone PHP
+
 This milestone will be for implementing a Solid identity provider in PHP,
 that passes the test-suite from the previous milestone.
 
-## 1c. Nextcloud Integration
+### 1c. Nextcloud Integration
+
 This milestone will be for integrating the Solid identity provider from the previous
 milestone into Nextcloud, as a Nextcloud app, in such a way that Nextcloud's existing
 single sign-on feature will be used as the user login database.
 
-# 2. Storage API
-## 2a. Test Suite
+## 2. Storage API
+
+### 2a. Test Suite
+
 This milestone will be for providing a test suite that tests the different behaviours which
 the storage API of a Solid server needs to implement. Part of this is already tested by the LDP-BasicContainer
 test-suite, but for many details such as filename encoding, recursive deletes, sparql-update
@@ -40,13 +67,16 @@ implementation projects to benefit from. The exact test criteria this test suite
 will be detailed on a dedicated public web page on https://pdsinterop.org/, with links
 to the relevant sections in the official Solid spec.
 
-## 2b. Implementation
+### 2b. Implementation
+
 This milestone will include both the implementation of the Solid storage API in PHP, and the integration
 of that component into the Nextcloud app which was created in milestone 1c. It encompasses the various
 HTTP verbs, as well as RDF-aware parts like sparql-update and content-negotiation.
 
-# 3. Web ACL
-## 3a. Test Suite
+## 3. Web ACL
+
+### 3a. Test Suite
+
 The Web ACL protocol is quite complex and at times confusing. One description of it
 is available at https://github.com/solid/web-access-control-spec, and a slightly more
 readable and explicit interpretation of it is available at https://unhosted.org/using-solid/.
@@ -59,12 +89,15 @@ ensures that our implementation is both correct as intended, and compatible with
 The exact test criteria this test-suite tests for will be detailed on a dedicated public web page on
 https://pdsinterop.org/, with links to the relevant sections in the official Solid spec.
 
-## 3b. Implementation
+### 3b. Implementation
+
 This milestone will include both the implementation of the Web Access Control spec in PHP, and the integration
 of that component into the Nextcloud app which was created in milestone 1c.
 
-# 4. Deep Integration
-## 4a. Solid App Launcher
+## 4. Deep Integration
+
+### 4a. Solid App Launcher
+
 A crucial part of Solid is allowing the user to control who gets access to which part of their data. The basis
 for this was developed last year at Inrupt, called the Solid App Launcher, which we need to update and integrate
 into the user interface of both the stand-alone server and the Nextcloud integration app.
@@ -72,7 +105,8 @@ The index of apps this launcher recognizes, and exact permissions each app reque
 will be detailed on a dedicated public web page on https://pdsinterop.org/, with links
 to the relevant sections in the official Solid spec.
 
-## 4b. Contacts and Profile
+### 4b. Contacts and Profile
+
 Nextcloud users already have profile data like full name and avatar in their user account, and they also already
 have a Nextcloud addressbook in which they keep track of their contacts, for instance for sharing Nextcloud documents.
 For this milestone we will unlock this data and make it available in the RDF-based Solid data format for profile and
@@ -80,7 +114,8 @@ contacts data.
 The details of both the Solid and the Nextcloud data format for this will be detailed on a dedicated public web page
 on https://pdsinterop.org/, with links to the relevant sections in the official Solid spec.
 
-## 4c. Calendar
+### 4c. Calendar
+
 Same as 4b. but unlocking the user's Nextcloud-native calendar events as Solid-native calendar events. Where certain
 fields don't have a mapping (e.g. if the Solid format has a maximum number of attendees for an event, but the Nextcloud
 format does not), they will simply be left blank. Other than that, it will be a great way to bootstrap the Solid app


### PR DESCRIPTION
As discussed during last week's meeting, this MR splits various larger milestones into smaller ones.

Most notably, for the first milestone "Identity" the read-only profile has been separated from the Authentication milestone.

Later milestones have the generic PHP part split off from the Nextcloud integration.

To make the distinction between larger and smaller milestones clear, I have also added an overview at the beginning.

I have tried to leave the original wording intact as much as I could.